### PR TITLE
feat: generateQueryString, pages/api/accounts 구현

### DIFF
--- a/preface/lib/types/types.ts
+++ b/preface/lib/types/types.ts
@@ -1,0 +1,9 @@
+export interface Queries {
+  q?: string | string[];
+  _page?: string | string[];
+  _limit?: string | string[];
+  _sort?: string | string[];
+  _order?: string | string[];
+}
+
+export type QueryKeys = keyof Queries;

--- a/preface/lib/utils/generateQueryString.ts
+++ b/preface/lib/utils/generateQueryString.ts
@@ -1,0 +1,13 @@
+import { Queries, QueryKeys } from "lib/types/types";
+
+export const generateQueryString = (query: Queries) => {
+  const queryList: string[] = [];
+  let key: QueryKeys | undefined;
+  for (key in query) {
+    const queryKey = key;
+    if (queryKey && query[queryKey]) {
+      queryList.push(`${queryKey}=${query[queryKey]}`);
+    }
+  }
+  return queryList.length !== 0 ? `?${queryList.join("&")}` : "";
+};

--- a/preface/model/model.ts
+++ b/preface/model/model.ts
@@ -1,7 +1,66 @@
+export const Brokers = {
+  "209": "유안타증권",
+  "218": "현대증권",
+  "230": "미래에셋증권",
+  "238": "대우증권",
+  "240": "삼성증권",
+  "243": "한국투자증권",
+  "247": "우리투자증권",
+  "261": "교보증권",
+  "262": "하이투자증권",
+  "263": "HMC투자증권",
+  "264": "키움증권",
+  "265": "이베스트투자증권",
+  "266": "SK증권",
+  "267": "대신증권",
+  "268": "아이엠투자증권",
+  "269": "한화투자증권",
+  "270": "하나대투자증권",
+  "279": "동부증권",
+  "280": "유진투자증권",
+  "288": "카카오페이증권",
+  "287": "메리츠종합금융증권",
+  "290": "부국증권",
+  "291": "신영증권",
+  "292": "LIG투자증권",
+  "271": "토스증권"
+} as const;
+
+type BrokersObject = typeof Brokers;
+export type TBrokersKey = keyof BrokersObject;
+export type TBrokersValue = BrokersObject[TBrokersKey];
+
+export const AccountStatus = {
+  9999: "관리자확인필요",
+  1: "입금대기",
+  2: "운용중",
+  3: "투자중지",
+  4: "해지"
+} as const;
+
+type AccountStatusObject = typeof AccountStatus;
+export type TAccountStatusKey = keyof AccountStatusObject;
+export type TAccountStatusValue = AccountStatusObject[TAccountStatusKey];
+
 export interface UserModel {
   accessToken: string;
   user: {
     email: string;
     id: number;
   };
+}
+
+export interface AccountModel {
+  id: number;
+  user_id: number;
+  uuid: string;
+  broker_id: TBrokersKey;
+  status: TAccountStatusKey;
+  number: string;
+  name: string;
+  assets: string;
+  payments: string;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
 }

--- a/preface/pages/api/accounts/index.ts
+++ b/preface/pages/api/accounts/index.ts
@@ -1,8 +1,32 @@
+import axios, { AxiosResponseHeaders } from "axios";
+import { generateQueryString } from "lib/utils/generateQueryString";
+import { AccountModel } from "model/model";
 import type { NextApiRequest, NextApiResponse } from "next";
+import CookieService from "service/CookieService";
 
-export default async function handler(
+export default async function accountsHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  res.status(200).json({ data: "hi" });
+  const { method, query } = req;
+
+  switch (method) {
+    case "GET": {
+      const queries = generateQueryString(query);
+      const { accessToken } = CookieService.getCookies({ req, res });
+      const response = await axios.get<AccountModel[]>(
+        `http://localhost:4000/accounts${queries}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          }
+        }
+      );
+
+      const responseHeaders = response.headers as AxiosResponseHeaders;
+      const accounts = response.data;
+      const totalItems = Number(responseHeaders.get("x-total-count"));
+      return res.status(200).json({ accounts, totalItems });
+    }
+  }
 }


### PR DESCRIPTION
api/accounts 구현
- /api/accounts<your-query> 로 요청할 수 있습니다. querystring은 자유이며 q= _page, _limit, _order, _sort 의 규칙만 지켜서 넘기면 됩니다. generateQueryString
- 이 함수는 query를 받아 undefined를 걸러 값이 채워져 있는 query만 query string으로 변환합니다. types
- Queries 추가 model.ts 모델 추가
- Brokers
- BrokersObject
- TBrokersKey
- TBrokersValue
- AccountStatus
- AccountStatusObject
- TAccountStatusKey
- TAccountStatusValue
- AccountModel